### PR TITLE
fix sorted timezone

### DIFF
--- a/src/post_processing/utils/filtering_utils.py
+++ b/src/post_processing/utils/filtering_utils.py
@@ -173,7 +173,7 @@ def get_timezone(df: DataFrame) -> tzoffset | list[tzoffset]:
     timezones = {ts.tz for ts in df["start_datetime"] if ts.tz is not None}
     if len(timezones) == 1:
         return next(iter(timezones))
-    return sorted(timezones)
+    return sorted(timezones, key=lambda tz: tz.utcoffset(None))
 
 
 def reshape_timebin(


### PR DESCRIPTION
I modified the return of get_timezone function as it generated an error (TypeError: '<' not supported between instances of 'datetime.timezone' and 'datetime.timezone') when I had different timezones in my dataframe.  