### PR TITLE
optimized core/get_count function

### DIFF
--- a/src/disclose/utils/core.py
+++ b/src/disclose/utils/core.py
@@ -17,9 +17,11 @@ from pandas import (
     date_range,
     json_normalize,
     to_datetime,
+    Series,
 )
 from pandas.tseries import offsets
 from pandas.tseries.offsets import BaseOffset
+
 
 if TYPE_CHECKING:
     from datetime import tzinfo
@@ -335,7 +337,10 @@ def add_recording_period(
 
 
 def get_count(
-    df: DataFrame, bin_size: Timedelta | BaseOffset, time: DatetimeIndex | None = None
+    df: DataFrame,
+    bin_size: Timedelta | BaseOffset,
+    time: DatetimeIndex | None = None,
+    effort: Any | None = None,
 ) -> DataFrame:
     """Count observations per label and annotator.
 
@@ -350,6 +355,8 @@ def get_count(
         Width or frequency of bins.
     time: DatetimeIndex
         DatetimeIndex from a specified beginning to end
+    effort: Any | None
+        Recording periods reflecting the effort of observation.
 
     Returns
     -------
@@ -362,9 +369,28 @@ def get_count(
         msg = "`df` contains no data"
         raise ValueError(msg)
 
-    datetime_list = list(df["start_datetime"]) if time is None else time.to_list()
+    if effort is not None:
+        eff = Series(effort.counts.to_numpy(), index=effort.counts.index.left)
+        bin_activity = eff.resample(bin_size, closed="left", label="left").sum()
+        active_starts = bin_activity[bin_activity > 0].index
 
-    bins, bin_size = get_time_range_and_bin_size(datetime_list, bin_size)
+        if active_starts.empty:
+            msg = "`effort` contains no recording activity"
+            raise ValueError(msg)
+
+        # Build cut edges only from active bins (start and start + bin_size)
+        active_ends = active_starts + bin_size
+        bins = DatetimeIndex(sorted(set(active_starts) | set(active_ends)))
+
+        # Restrict events to the active window span (cheap pre-filter)
+        df = df[
+            (df["start_datetime"] >= active_starts.min())
+            & (df["start_datetime"] < active_ends.max())
+        ]
+    else:
+        datetime_list = list(df["start_datetime"]) if time is None else time.to_list()
+        bins, bin_size = get_time_range_and_bin_size(datetime_list, bin_size)
+        active_starts = bins[:-1]
 
     labels, annotators = get_labels_and_annotators(df)
 
@@ -373,7 +399,7 @@ def get_count(
         for label, annotator in zip(labels, annotators, strict=False)
     ]
 
-    counts_df = DataFrame(index=bins[:-1])
+    counts_df = DataFrame(index=active_starts)
     for i, series in enumerate(series_list):
         binned = cut(series, bins=bins, right=False)
         counts_df[f"{labels[i]}-{annotators[i]}"] = binned.value_counts().sort_index()
@@ -403,7 +429,7 @@ def get_labels_and_annotators(df: DataFrame) -> tuple[list, list]:
 
 
 def localize_timestamps(timestamps: list[Timestamp], tz: tzinfo) -> list[Timestamp]:
-    """Localise timestamps if necessary."""
+    """Localize timestamps if necessary."""
     localized = []
     for ts in timestamps:
         if ts.tzinfo is None or ts.tzinfo.utcoffset(ts) is None:

--- a/src/disclose/utils/visualisation.py
+++ b/src/disclose/utils/visualisation.py
@@ -587,8 +587,8 @@ def timeline(
     ax.set_yticklabels(labels[::-1])
     ax.set_xlabel("Date")
     ax.set_xlim(
-        df["start_datetime"].min().floor("1d"),
-        df["end_datetime"].max().ceil("1d"),
+        df["start_datetime"].min().floor("1D"),
+        df["end_datetime"].max().ceil("1D"),
     )
 
 

--- a/tests/test_DataAplose.py
+++ b/tests/test_DataAplose.py
@@ -271,7 +271,7 @@ def test_plot_scatter_heatmap_timeline(sample_df: DataFrame, mode: str) -> None:
     data = DataAplose(sample_df)
     data.lon = 0
     data.lat = 0
-    bin_size = frequencies.to_offset("1d")
+    bin_size = frequencies.to_offset("1D")
     fig, ax = plt.subplots()
     data.plot(
         mode=mode, ax=ax, annotator="ann1", label="lbl1", bin_size=bin_size, color="red"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,10 +2,11 @@ from unittest.mock import patch
 
 import pytest
 from matplotlib import pyplot as plt
-from pandas import DataFrame, Timedelta, Timestamp, date_range
+from pandas import DataFrame, Timedelta, Timestamp, date_range, IntervalIndex, Series
 from pandas.tseries import frequencies
 from pytz import timezone
 
+from dataclass.recording_period import RecordingPeriod
 from disclose.dataclass.data_aplose import DataAplose
 from disclose.utils.core import (
     add_recording_period,
@@ -23,6 +24,7 @@ from disclose.utils.core import (
     timedelta_to_str,
 )
 from disclose.utils.filtering import add_weak_detection
+from utils.filtering import get_max_time
 
 
 def test_coordinates_valid_input(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -221,6 +223,89 @@ def test_get_count_multiple_labels_annotators(sample_df: DataFrame) -> None:
 def test_get_count_empty_df() -> None:
     with pytest.raises(ValueError, match="`df` contains no data"):
         get_count(DataFrame(), Timedelta("1h"))
+
+
+def _make_effort(
+    active_windows: list[tuple[Timestamp, Timestamp]],
+    full_start: Timestamp,
+    full_end: Timestamp,
+    origin: Timedelta,
+) -> RecordingPeriod:
+    """Build a fake RecordingPeriod-like object with fine-grained on/off samples.
+
+    `active_windows` are [start, end) spans marked as recording (1);
+    everything else in [full_start, full_end) is 0.
+    """
+    idx = date_range(full_start, full_end, freq=origin, inclusive="left")
+    values = Series(0, index=idx)
+    for start, end in active_windows:
+        values.loc[(values.index >= start) & (values.index < end)] = 1
+    counts = Series(
+        values.to_numpy(),
+        index=IntervalIndex.from_arrays(idx, idx + origin, closed="left"),
+    )
+    return RecordingPeriod(counts=counts, timebin_origin=origin)
+
+
+def test_get_count_with_effort_restricts_to_active_bins(sample_df: DataFrame) -> None:
+    df = DataAplose(sample_df).filter_df(annotator="ann1", label="lbl1")
+    bin = get_max_time(df)
+    start = df["start_datetime"].min()
+    stop = df["start_datetime"].min() + Timedelta("1min")
+
+    effort = _make_effort(
+        active_windows=[(start, stop)],
+        full_start=start,
+        full_end=stop,
+        origin=bin,
+    )
+
+    result = get_count(df, bin_size=bin, effort=effort)
+
+    assert result.index.min() == start
+    assert result.index.max() < stop
+
+
+def test_get_count_with_effort_all_zero_raises(sample_df: DataFrame) -> None:
+    df = DataAplose(sample_df).filter_df(annotator="ann1", label="lbl1")
+
+    start = df["start_datetime"].min()
+    stop = df["start_datetime"].min() + Timedelta("1min")
+    bin = get_max_time(df)
+
+    effort = _make_effort(
+        active_windows=[],
+        full_start=start,
+        full_end=stop,
+        origin=bin,
+    )
+
+    with pytest.raises(ValueError, match="`effort` contains no recording activity"):
+        get_count(df, bin_size=Timedelta("1h"), effort=effort)
+
+
+def test_get_count_with_effort_matches_full_coverage(sample_df: DataFrame) -> None:
+    df = DataAplose(sample_df).filter_df(annotator="ann1", label="lbl1")
+
+    bin = get_max_time(df)
+    start = df["start_datetime"].min()
+    stop = df["start_datetime"].max() + bin
+
+    effort = _make_effort(
+        active_windows=[(start, stop)],
+        full_start=start,
+        full_end=stop,
+        origin=bin,
+    )
+
+    result_with_effort = get_count(df, bin_size=bin, effort=effort)
+    result_without_effort = get_count(df, bin_size=bin)
+
+    assert list(result_with_effort.index) == list(result_without_effort.index)
+    assert (
+        result_with_effort["lbl1-ann1"].sum()
+        == result_without_effort["lbl1-ann1"].sum()
+    )
 
 
 # %% get_labels_and_annotators

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, Timedelta, Timestamp, date_range, IntervalIndex, S
 from pandas.tseries import frequencies
 from pytz import timezone
 
-from dataclass.recording_period import RecordingPeriod
+from disclose.dataclass.recording_period import RecordingPeriod
 from disclose.dataclass.data_aplose import DataAplose
 from disclose.utils.core import (
     add_recording_period,
@@ -23,8 +23,7 @@ from disclose.utils.core import (
     set_bar_height,
     timedelta_to_str,
 )
-from disclose.utils.filtering import add_weak_detection
-from utils.filtering import get_max_time
+from disclose.utils.filtering import add_weak_detection, get_max_time
 
 
 def test_coordinates_valid_input(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -179,7 +178,7 @@ def test_get_count_basic(sample_df: DataFrame) -> None:
 
 def test_get_count_multiple_annotators(sample_df: DataFrame) -> None:
     df = DataAplose(sample_df).filter_df(annotator=["ann1", "ann2"], label="lbl1")
-    result = get_count(df, bin_size=Timedelta("1d"))
+    result = get_count(df, bin_size=Timedelta("1D"))
     expected = sample_df[
         (sample_df["annotator"].isin(["ann1", "ann2"])) & (sample_df["label"] == "lbl1")
     ]
@@ -231,7 +230,7 @@ def _make_effort(
     full_end: Timestamp,
     origin: Timedelta,
 ) -> RecordingPeriod:
-    """Build a fake RecordingPeriod-like object with fine-grained on/off samples.
+    """Build a fake RecordingPeriod object with fine-grained on/off samples.
 
     `active_windows` are [start, end) spans marked as recording (1);
     everything else in [full_start, full_end) is 0.
@@ -506,7 +505,7 @@ def test_add_season_valid() -> None:
     _, ax = plt.subplots()
     start = Timestamp("2025-01-01")
     stop = Timestamp("2026-01-01")
-    freq = Timedelta("1d")
+    freq = Timedelta("1D")
     ts = date_range(start=start, end=stop, freq=freq, tz="UTC")
     values = [date.day for date in ts]
     [ax.bar(loc + freq, height) for loc, height in zip(ts, values, strict=True)]


### PR DESCRIPTION
Restrict `get_count` binning to periods with recording effort to avoid computing empty bins and cut runtime on large datasets.