### PR TITLE
atomization into smaller helpers + tests

### DIFF
--- a/src/disclose/dataclass/data_aplose.py
+++ b/src/disclose/dataclass/data_aplose.py
@@ -500,10 +500,14 @@ class DataAplose:
             raise ValueError(msg)
         timebin = Timedelta(df_filtered["end_time"].iloc[0], "s")
 
+        if self.config.recording_file:
+            effort = RecordingPeriod.from_config(config=self.config, bin_size=timebin)
+
         return detection_perf(
             df=df_filtered,
             ref=ref,
             time=date_range(self.start_datetime, self.end_datetime, freq=timebin),
+            effort=effort,
         )
 
     def plot(

--- a/src/disclose/utils/metric.py
+++ b/src/disclose/utils/metric.py
@@ -7,7 +7,7 @@ from typing import TypedDict
 
 from pandas import DataFrame, DatetimeIndex, Series, Timestamp
 
-from dataclass.recording_period import RecordingPeriod
+from disclose.dataclass.recording_period import RecordingPeriod
 from disclose.utils.core import get_count
 from disclose.utils.filtering import (
     get_annotators,

--- a/src/disclose/utils/metric.py
+++ b/src/disclose/utils/metric.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
+from typing import TypedDict
 
-import numpy as np
-from pandas import DataFrame, DatetimeIndex
+from pandas import DataFrame, DatetimeIndex, Series, Timestamp
 
+from dataclass.recording_period import RecordingPeriod
 from disclose.utils.core import get_count
 from disclose.utils.filtering import (
     get_annotators,
@@ -16,68 +17,64 @@ from disclose.utils.filtering import (
 )
 
 
-def detection_perf(
-    df: DataFrame,
-    *,
-    ref: tuple[str, str],
-    time: DatetimeIndex | None = None,
-) -> tuple[float, float, float]:
-    """Compute the performance metrics for detection.
+class Classification(TypedDict):
+    true_positive: list[Timestamp]
+    false_positive: list[Timestamp]
+    true_negative: list[Timestamp]
+    false_negative: list[Timestamp]
+    error: list[Timestamp]
 
-    Performances are computed with a reference annotator/label pair
-    in comparison to a second annotator/label pair.
+
+class ConfusionMatrix(TypedDict):
+    true_positive: int
+    false_positive: int
+    true_negative: int
+    false_negative: int
+    error: int
+
+
+Scores = tuple[float, float, float]
+
+
+def _get_classification_timestamps(
+    vec1: Series,
+    vec2: Series,
+) -> dict[str, list[Timestamp]]:
+    """Return timestamps classified as true/false positives/negatives or errors.
+
+    Both vectors are expected to contain binary values (0 or 1), with other
+    values classified as errors.
+    """
+    true_pos_mask = (vec1 == 1) & (vec2 == 1)
+    false_pos_mask = (vec1 == 0) & (vec2 == 1)
+    false_neg_mask = (vec1 == 1) & (vec2 == 0)
+    true_neg_mask = (vec1 == 0) & (vec2 == 0)
+    error_mask = (~vec1.isin([0, 1])) | (~vec2.isin([0, 1]))
+
+    return {
+        "true_pos": vec1.index[true_pos_mask].tolist(),
+        "false_pos": vec1.index[false_pos_mask].tolist(),
+        "false_neg": vec1.index[false_neg_mask].tolist(),
+        "true_neg": vec1.index[true_neg_mask].tolist(),
+        "error": vec1.index[error_mask].tolist(),
+    }
+
+
+def _compute_confusion_matrix(timestamps: dict[str, list[Timestamp]]) -> dict[str, int]:
+    """Compute the confusion matrix counts from classified timestamps.
 
     Parameters
     ----------
-    df: DataFrame
-        APLOSE formatted detection DataFrame
-    ref: tuple[str, str]
-        Tuple of annotator/detector pairs.
-    time: DatetimeIndex
-        DatetimeIndex from a specified beginning to end
+    timestamps: dict[str, list[Timestamp]]
+        Lists of timestamps for each category, true/false positives/negatives or errors
 
     Returns
     -------
-    precision: float
-    recall: float
-    f_score: float
+    confusion_matrix: dict[str, int]
+        Counts for true_pos, false_pos, false_neg, true_neg, error
 
     """
-    annotators = get_annotators(df)
-    if len(annotators) != 2:  # noqa: PLR2004
-        msg = f"Two annotators needed, DataFrame contains {len(annotators)} annotators"
-        raise ValueError(msg)
-
-    labels = get_labels(df)
-
-    timebin = get_max_time(df)
-    df_count = get_count(df, timebin, time)
-
-    # reference annotator and label
-    annotator1, label1 = ref
-    detections1 = df[(df["annotator"] == annotator1) & (df["label"] == label1)]
-    if detections1.empty:
-        msg = f"No detection found for {annotator1}/{label1}"
-        raise ValueError(msg)
-    vec1 = df_count[f"{label1}-{annotator1}"]
-
-    # second annotator and label
-    annotator2 = next(ant for ant in annotators if ant != annotator1)
-    label2 = (
-        next(lbl for lbl in labels if lbl != label1)
-        if len(labels) == 2  # noqa: PLR2004
-        else label1
-    )
-    vec2 = df_count[f"{label2}-{annotator2}"]
-
-    # metrics computation
-    confusion_matrix = {
-        "true_pos": int(np.sum((vec1 == 1) & (vec2 == 1))),
-        "false_pos": int(np.sum((vec1 == 0) & (vec2 == 1))),
-        "false_neg": int(np.sum((vec1 == 1) & (vec2 == 0))),
-        "true_neg": int(np.sum((vec1 == 0) & (vec2 == 0))),
-        "error": int(np.sum((vec1 != 0) & (vec1 != 1) | (vec2 != 0) & (vec2 != 1))),
-    }
+    confusion_matrix = {key: len(values) for key, values in timestamps.items()}
 
     if confusion_matrix["error"] != 0:
         msg = f"{confusion_matrix['error']} errors in metric computation."
@@ -90,13 +87,117 @@ def detection_perf(
         msg = "Precision/Recall computation impossible."
         raise ValueError(msg)
 
-    _log_detection_results(
-        selection1=(annotator1, label1),
-        selection2=(annotator2, label2),
-        matrix=confusion_matrix,
-        df=df,
-    )
+    return confusion_matrix
 
+
+def _prepare_annotator_vectors(
+    df: DataFrame,
+    df_count: DataFrame,
+    ref: tuple[str, str],
+) -> tuple[Series, Series, tuple[str, str], tuple[str, str]]:
+    """Prepare the count vectors for the reference and second annotator/label pair.
+
+    Parameters
+    ----------
+    df: DataFrame
+        APLOSE formatted detection DataFrame
+    df_count: DataFrame
+        Detection counts per timebin, indexed by "{label}-{annotator}" columns
+    ref: tuple[str, str]
+        Reference annotator/label pair
+
+    Returns
+    -------
+    vec1: Series
+        Count vector for the reference annotator/label
+    vec2: Series
+        Count vector for the second annotator/label
+    selection1: tuple[str, str]
+        (annotator1, label1)
+    selection2: tuple[str, str]
+        (annotator2, label2)
+
+    """
+    annotators = get_annotators(df)
+    annotators = [annotators] if isinstance(annotators, str) else annotators
+    if len(annotators) != 2:  # noqa: PLR2004
+        msg = f"Two annotators needed, DataFrame contains {len(annotators)} annotators"
+        raise ValueError(msg)
+
+    labels = get_labels(df)
+
+    annotator1, label1 = ref
+    detections1 = df[(df["annotator"] == annotator1) & (df["label"] == label1)]
+    if detections1.empty:
+        msg = f"No detection found for {annotator1}/{label1}"
+        raise ValueError(msg)
+    vec1 = df_count[f"{label1}-{annotator1}"]
+
+    annotator2 = next(ant for ant in annotators if ant != annotator1)
+    label2 = (
+        next(lbl for lbl in labels if lbl != label1)
+        if len(labels) == 2  # noqa: PLR2004
+        else label1
+    )
+    vec2 = df_count[f"{label2}-{annotator2}"]
+
+    return vec1, vec2, (annotator1, label1), (annotator2, label2)
+
+
+def get_detection_timestamps(
+    df: DataFrame,
+    *,
+    ref: tuple[str, str],
+    time: DatetimeIndex | None = None,
+    effort: RecordingPeriod | None = None,
+) -> dict[str, list[Timestamp]]:
+    """Retrieve the timestamps classified as true_pos/false_pos/false_neg/true_neg/error.
+
+    Useful for verification purposes, e.g. inspecting the exact
+    false-positive timebins for a given annotator/label pair.
+
+    Parameters
+    ----------
+    df: DataFrame
+        APLOSE formatted detection DataFrame
+    ref: tuple[str, str]
+        Reference annotator/label pair
+    time: DatetimeIndex
+        DatetimeIndex from a specified beginning to end
+    effort: RecordingPeriod
+        Recording effort period
+
+    Returns
+    -------
+    timestamps: dict[str, list[Timestamp]]
+        Lists of timestamps for each category: true_pos, false_pos,
+        false_neg, true_neg, error
+
+    """
+    timebin = get_max_time(df)
+    df_count = get_count(df, timebin, time, effort)
+
+    vec1, vec2, _, _ = _prepare_annotator_vectors(df, df_count, ref)
+    return _get_classification_timestamps(vec1, vec2)
+
+
+def _compute_scores(
+    confusion_matrix: dict[str, int],
+) -> tuple[float | int, float | int, float | int]:
+    """Compute precision, recall and f-score from a confusion matrix.
+
+    Parameters
+    ----------
+    confusion_matrix: dict[str, int]
+        Counts for true_pos, false_pos, false_neg, true_neg, error
+
+    Returns
+    -------
+    precision: float
+    recall: float
+    f_score: float
+
+    """
     return (
         _get_precision(confusion_matrix),
         _get_recall(confusion_matrix),
@@ -130,6 +231,7 @@ def _log_detection_results(
     selection2: tuple[str, str],
     matrix: dict,
     df: DataFrame,
+    effort: RecordingPeriod | None = None,
 ) -> None:
     """Log detection performance results."""
     annotator1, label1 = selection1
@@ -149,7 +251,60 @@ def _log_detection_results(
         f"{'Precision:':<25}{precision:>25.2f}\n"
         f"{'Recall:':<25}{recall:>25.2f}\n"
         f"{'F-score:':<25}{f_score:>25.2f}\n\n"
-        f"{'Union:':<25}{len(intersection_or_union(df, 'union')):>25.0f}\n"
-        f"{'Intersection:':<25}{len(intersection_or_union(df, 'intersection')):>25.0f}\n"
+        f"{'Union:':<25}{len(intersection_or_union(df, 'union', effort)):>25.0f}\n"
+        f"{'Intersection:':<25}{len(intersection_or_union(df, 'intersection', effort)):>25.0f}\n"
     )
     logging.info(msg_result)
+
+
+def detection_perf(
+    df: DataFrame,
+    *,
+    ref: tuple[str, str],
+    time: DatetimeIndex | None = None,
+    effort: RecordingPeriod | None = None,
+) -> tuple[Scores, ConfusionMatrix, Classification]:
+    """Compute the performance metrics for detection.
+
+    Performances are computed with a reference annotator/label pair
+    in comparison to a second annotator/label pair.
+
+    Parameters
+    ----------
+    df: DataFrame
+        APLOSE formatted detection DataFrame
+    ref: tuple[str, str]
+        Tuple of annotator/detector pairs.
+    time: DatetimeIndex
+        DatetimeIndex from a specified beginning to end
+    effort: RecordingPeriod
+        Recording effort period
+
+    Returns
+    -------
+    score: Scores
+        precision, recall and f-score
+    confusion_matrix: ConfusionMatrix
+        Count of each category: true positive, false positive, true negative, false negative, error
+    classification: Classification
+        Lists of timestamps for each category: true positive, false positive, true negative, false negative, error
+
+    """
+    timebin = get_max_time(df)
+    df_count = get_count(df, timebin, time, effort)
+
+    vec1, vec2, selection1, selection2 = _prepare_annotator_vectors(df, df_count, ref)
+
+    classification = _get_classification_timestamps(vec1, vec2)
+    confusion_matrix = _compute_confusion_matrix(classification)
+    score = _compute_scores(confusion_matrix)
+
+    _log_detection_results(
+        selection1=selection1,
+        selection2=selection2,
+        matrix=confusion_matrix,
+        df=df,
+        effort=effort,
+    )
+
+    return score, confusion_matrix, classification

--- a/tests/test_DataAplose.py
+++ b/tests/test_DataAplose.py
@@ -499,56 +499,6 @@ def test_data_aplose_overview(monkeypatch, sample_df: DataFrame) -> None:
     assert called["annotator"] == annotator
 
 
-@pytest.mark.parametrize(
-    ("annotators", "labels", "expected_ref"),
-    [
-        pytest.param(
-            ("ann1", "ann2"),
-            "lbl1",
-            ("ann1", "lbl1"),
-            id="annotators_tuple_labels_str",
-        ),
-        pytest.param(
-            "ann1",
-            ("lbl1", "lbl2"),
-            ("ann1", "lbl1"),
-            id="annotators_str_labels_tuple",
-        ),
-    ],
-)
-def test_data_aplose_detection_perf_wrapper_parametrized(
-    monkeypatch,
-    sample_df: DataFrame,
-    annotators: tuple[str, str] | str,
-    labels: tuple[str, str] | str,
-    expected_ref: tuple[str, str],
-) -> None:
-    obj = DataAplose(sample_df[sample_df["type"] == "WEAK"])
-
-    called = {}
-
-    def fake_detection_perf(
-        df: DataFrame, ref: tuple[str, str], time
-    ) -> tuple[float, float, float]:
-        called["df"] = df
-        called["ref"] = ref
-        called["time"] = time
-        return (0.1, 0.2, 0.3)
-
-    monkeypatch.setattr(
-        "disclose.dataclass.data_aplose.detection_perf",
-        fake_detection_perf,
-    )
-
-    result = obj.detection_perf(
-        annotator=annotators,
-        label=labels,
-    )
-
-    assert result == (0.1, 0.2, 0.3)
-    assert called["ref"] == expected_ref
-
-
 def test_detection_perf_multiple_timebins(sample_df: DataFrame) -> None:
     obj = DataAplose(sample_df)
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,102 +1,323 @@
-from contextlib import nullcontext
-from typing import ContextManager
+from unittest.mock import patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
-from numpy import array
-from pandas import DataFrame
+from pandas import DataFrame, Series, date_range, Timestamp, Timedelta
 
-from disclose.utils.metric import detection_perf
-
-
-@pytest.mark.parametrize(
-    ("filter_annotator", "filter_label", "ref", "expected"),
-    [
-        pytest.param(
-            ["ann1", "ann4"],
-            None,
-            ("ann1", "lbl1"),
-            nullcontext(),
-            id="no_timestamps_provided",
-        ),
-        pytest.param(
-            ["ann1"],
-            None,
-            ("ann1", "lbl1"),
-            pytest.raises(ValueError, match="Two annotators needed"),
-            id="one_annotator_provided",
-        ),
-        pytest.param(
-            ["ann1", "ann6"],
-            ["lbl1"],
-            ("ann1", "lbl6"),
-            pytest.raises(ValueError, match="No detection found for ann1/lbl6"),
-            id="empty_ref_df",
-        ),
-    ],
+from disclose.utils.metric import (
+    detection_perf,
+    _get_classification_timestamps,
+    _compute_confusion_matrix,
+    _prepare_annotator_vectors,
+    get_detection_timestamps,
+    _get_f_score,
+    _get_recall,
+    _get_precision,
+    _compute_scores,
+    _log_detection_results,
 )
-def test_detection_perf(
-    sample_df: DataFrame,
-    filter_annotator: list[str, str],
-    filter_label: list[str, str],
-    ref: tuple[str, str],
-    expected: ContextManager[Exception],
-) -> None:
-    filtered_df = sample_df[sample_df["type"] == "WEAK"]
-    if filter_annotator:
-        filtered_df = filtered_df[filtered_df["annotator"].isin(filter_annotator)]
-    if filter_label:
-        filtered_df = filtered_df[filtered_df["label"].isin(filter_label)]
-
-    with expected:
-        detection_perf(df=filtered_df, ref=ref)
+from utils.core import get_count
+from utils.filtering import get_annotators, get_labels
 
 
-def test_detection_perf_confusion_matrix_errors(
-    monkeypatch: MonkeyPatch,
-    sample_df: DataFrame,
-) -> None:
-    def fake_get_count(*args, **kwargs) -> DataFrame:
-        return DataFrame({
-            "lbl2-ann1": array([1, 1, 1, 0, 666, 1]),
-            "lbl2-ann2": array([1, 0, 2, 1, 0, 1234]),
-        })
+# %% _get_classification_timestamps
 
-    monkeypatch.setattr("disclose.utils.metric.get_count", fake_get_count)
 
-    filtered_df = sample_df[
-        (sample_df["label"] == "lbl2")
-        & (sample_df["annotator"].isin(["ann1", "ann2"]))
-        & (sample_df["type"] == "WEAK")
+def test_get_classification_timestamps():
+    timestamps = date_range("2026-08-01", periods=10, freq="h")
+
+    vec1 = Series([1, 0, 1, 0, 2, 0, 1, 1, 0, 1], index=timestamps)
+    vec2 = Series([1, 1, 0, 0, 2, 1, 1, 1, 0, "not_a_bolean"], index=timestamps)
+
+    result = _get_classification_timestamps(vec1, vec2)
+
+    assert result == {
+        "true_pos": [timestamps[0], timestamps[6], timestamps[7]],
+        "false_pos": [timestamps[1], timestamps[5]],
+        "false_neg": [timestamps[2]],
+        "true_neg": [timestamps[3], timestamps[8]],
+        "error": [timestamps[4], timestamps[-1]],
+    }
+
+
+# %% _compute_confusion_matrix
+
+
+def test_compute_confusion_matrix():
+    timestamps = {
+        "true_pos": [
+            Timestamp("2024-01-01"),
+            Timestamp("2024-01-02"),
+            Timestamp("2024-01-03"),
+        ],
+        "false_pos": [Timestamp("2024-01-04"), Timestamp("2024-01-05")],
+        "false_neg": [Timestamp("2024-01-06")],
+        "true_neg": [Timestamp("2024-01-07"), Timestamp("2024-01-08")],
+        "error": [],
+    }
+
+    result = _compute_confusion_matrix(timestamps)
+
+    assert result == {
+        "true_pos": 3,
+        "false_pos": 2,
+        "false_neg": 1,
+        "true_neg": 2,
+        "error": 0,
+    }
+
+
+def test_compute_confusion_matrix_raises_on_errors():
+    timestamps = {
+        "true_pos": [Timestamp("2024-01-01")],
+        "false_pos": [],
+        "false_neg": [Timestamp("2024-01-02")],
+        "true_neg": [],
+        "error": [Timestamp("2024-01-03")],
+    }
+
+    with pytest.raises(ValueError, match="1 errors in metric computation."):
+        _compute_confusion_matrix(timestamps)
+
+
+def test_compute_confusion_matrix_raises_when_precision_impossible():
+    timestamps = {
+        "true_pos": [],
+        "false_pos": [],
+        "false_neg": [Timestamp("2024-01-01")],
+        "true_neg": [Timestamp("2024-01-02")],
+        "error": [],
+    }
+
+    with pytest.raises(ValueError, match="Precision/Recall computation impossible."):
+        _compute_confusion_matrix(timestamps)
+
+
+def test_compute_confusion_matrix_raises_when_recall_impossible():
+    timestamps = {
+        "true_pos": [],
+        "false_pos": [Timestamp("2024-01-01")],
+        "false_neg": [],
+        "true_neg": [Timestamp("2024-01-02")],
+        "error": [],
+    }
+
+    with pytest.raises(ValueError, match="Precision/Recall computation impossible."):
+        _compute_confusion_matrix(timestamps)
+
+
+# %% _prepare_annotator_vectors
+
+
+def test_prepare_annotator_vectors(sample_df: DataFrame):
+    sample_df_2_ann = sample_df[
+        (sample_df["annotator"].isin(["ann1", "ann2"])) & (sample_df["label"] == "lbl1")
     ]
+    df_count = get_count(df=sample_df_2_ann, bin_size=Timedelta("10min"))
 
-    with pytest.raises(ValueError, match="3 errors in metric computation"):
-        detection_perf(
-            filtered_df,
-            ref=("ann1", "lbl2"),
+    anns = get_annotators(sample_df_2_ann)
+    lbl = get_labels(sample_df_2_ann)
+
+    vec1, vec2, selection1, selection2 = _prepare_annotator_vectors(
+        sample_df_2_ann,
+        df_count,
+        ref=(anns[0], lbl),
+    )
+
+    assert selection1 == (anns[0], lbl)
+    assert selection2 == (anns[1], lbl)
+    assert all(vec1 == df_count["lbl1-ann1"])
+    assert all(vec2 == df_count["lbl1-ann2"])
+
+
+def test_prepare_annotator_vectors_requires_two_annotators(sample_df: DataFrame):
+    sample_df_1_ann = sample_df[sample_df["annotator"] == "ann1"]
+    df_count = get_count(df=sample_df_1_ann, bin_size=Timedelta("10min"))
+
+    with pytest.raises(
+        ValueError,
+        match="Two annotators needed, DataFrame contains 1 annotators",
+    ):
+        _prepare_annotator_vectors(
+            sample_df_1_ann,
+            df_count,
+            ref=("ann1", "lbl1"),
         )
 
 
-def test_detection_perf_confusion_matrix_no_data(
-    monkeypatch: MonkeyPatch,
-    sample_df: DataFrame,
-) -> None:
-    def fake_get_count(*args, **kwargs) -> DataFrame:
-        return DataFrame({
-            "lbl2-ann1": array([0] * 10),
-            "lbl2-ann2": array([0] * 10),
-        })
+def test_prepare_annotator_vectors_reference_not_found(sample_df: DataFrame):
+    sample_df_2_ann = sample_df[sample_df["annotator"].isin(["ann1", "ann2"])]
+    df_count = get_count(df=sample_df_2_ann, bin_size=Timedelta("10min"))
 
-    monkeypatch.setattr("disclose.utils.metric.get_count", fake_get_count)
+    with pytest.raises(
+        ValueError,
+        match="No detection found for ann1/laymelli",
+    ):
+        _prepare_annotator_vectors(
+            sample_df_2_ann,
+            df_count,
+            ref=("ann1", "laymelli"),
+        )
 
-    filtered_df = sample_df[
-        (sample_df["label"] == "lbl2")
-        & (sample_df["annotator"].isin(["ann1", "ann2"]))
-        & (sample_df["type"] == "WEAK")
+
+# %% get_detection_timestamps
+
+
+def test_get_detection_timestamps(sample_df: DataFrame):
+    sample_df_2_ann = sample_df[
+        (sample_df["annotator"].isin(["ann1", "ann2"])) & (sample_df["label"] == "lbl1")
     ]
 
-    with pytest.raises(ValueError, match="Precision/Recall computation impossible"):
-        detection_perf(
-            filtered_df,
-            ref=("ann1", "lbl2"),
+    timestamps = get_detection_timestamps(
+        sample_df_2_ann,
+        ref=("ann1", "lbl1"),
+    )
+
+    assert set(timestamps) == {
+        "true_pos",
+        "false_pos",
+        "false_neg",
+        "true_neg",
+        "error",
+    }
+
+    assert all(
+        isinstance(timestamp, Timestamp)
+        for values in timestamps.values()
+        for timestamp in values
+    )
+
+
+# %% _get_precision / _get_recall / _get_f_score
+
+
+def test_get_precision():
+    confusion_matrix = {
+        "true_pos": 8,
+        "false_pos": 2,
+        "false_neg": 4,
+        "true_neg": 10,
+        "error": 0,
+    }
+
+    assert _get_precision(confusion_matrix) == 0.8
+
+
+def test_get_recall():
+    confusion_matrix = {
+        "true_pos": 8,
+        "false_pos": 2,
+        "false_neg": 4,
+        "true_neg": 10,
+        "error": 0,
+    }
+
+    assert _get_recall(confusion_matrix) == pytest.approx(8 / 12)
+
+
+def test_get_f_score():
+    confusion_matrix = {
+        "true_pos": 8,
+        "false_pos": 2,
+        "false_neg": 4,
+        "true_neg": 10,
+        "error": 0,
+    }
+
+    precision = 8 / 10
+    recall = 8 / 12
+    expected = 2 * (precision * recall) / (precision + recall)
+
+    assert _get_f_score(confusion_matrix) == pytest.approx(expected)
+
+
+# %% compute_score
+
+
+def test_compute_scores():
+    confusion_matrix = {
+        "true_pos": 8,
+        "false_pos": 2,
+        "false_neg": 4,
+        "true_neg": 10,
+        "error": 0,
+    }
+
+    precision, recall, f_score = _compute_scores(confusion_matrix)
+
+    assert precision == 0.8
+    assert recall == pytest.approx(8 / 12)
+    assert f_score == pytest.approx(2 * (0.8 * (8 / 12)) / (0.8 + (8 / 12)))
+
+
+# %% _log_detection_results
+
+
+def test_log_detection_results(sample_df: DataFrame):
+    matrix = {
+        "true_pos": 8,
+        "false_pos": 2,
+        "false_neg": 4,
+        "true_neg": 10,
+        "error": 0,
+    }
+
+    with patch("logging.info") as mock_info:
+        _log_detection_results(
+            selection1=("ann1", "lbl1"),
+            selection2=("ann2", "lbl1"),
+            matrix=matrix,
+            df=sample_df,
         )
+
+    log = mock_info.call_args[0][0]
+
+    assert "Detection results" in log
+    assert "ann1/lbl1" in log
+    assert "ann2/lbl1" in log
+    assert "True positive:" in log
+    assert "8" in log
+    assert "True negative:" in log
+    assert "10" in log
+    assert "False positive:" in log
+    assert "2" in log
+    assert "False negative:" in log
+    assert "4" in log
+    assert "Precision:" in log
+    assert "0.80" in log
+    assert "Recall:" in log
+    assert "0.67" in log
+    assert "F-score:" in log
+
+
+# %% detection_perf
+
+
+def test_detection_perf(sample_df: DataFrame):
+    sample_df_2_ann = sample_df[
+        (sample_df["annotator"].isin(["ann1", "ann2"])) & (sample_df["label"] == "lbl1")
+    ]
+
+    score, confusion_matrix, classification = detection_perf(
+        sample_df_2_ann,
+        ref=("ann1", "lbl1"),
+    )
+
+    assert set(classification) == {
+        "true_pos",
+        "false_pos",
+        "false_neg",
+        "true_neg",
+        "error",
+    }
+
+    assert confusion_matrix == {
+        "true_pos": len(classification["true_pos"]),
+        "false_pos": len(classification["false_pos"]),
+        "false_neg": len(classification["false_neg"]),
+        "true_neg": len(classification["true_neg"]),
+        "error": len(classification["error"]),
+    }
+
+    assert score[0] == 1
+    assert score[1] == 1
+    assert score[2] == 1

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -15,8 +15,8 @@ from disclose.utils.metric import (
     _compute_scores,
     _log_detection_results,
 )
-from utils.core import get_count
-from utils.filtering import get_annotators, get_labels
+from disclose.utils.core import get_count
+from disclose.utils.filtering import get_annotators, get_labels
 
 
 # %% _get_classification_timestamps


### PR DESCRIPTION
Created small helpers to simplify the metric code, especially the main function `detection_perf` to compute the performance metrics between 2 annotators.

Added unit tests covering the detection performance workflow, including timestamp classification, confusion matrix computation, precision/recall/F-score, result logging, and the main detection_perf function. Also covered the main validation/error cases.