### PR TITLE
Optimize get_count binning when recording effort is known

### DIFF
--- a/src/disclose/dataclass/recording_period.py
+++ b/src/disclose/dataclass/recording_period.py
@@ -18,6 +18,7 @@ from pandas import (
     read_csv,
     to_datetime,
     DataFrame,
+    concat,
 )
 
 from disclose.dataclass.data_aplose_config import DataAploseConfig
@@ -100,18 +101,24 @@ class RecordingPeriod:
             freq=origin,
         )
 
-        # Initialise effort vector (0 = no recording, 1 = recording)
-        # Compare each timestamp to all intervals in a vectorised manner
-        effort = Series(0, index=time_index)
+        starts = df["effective_start_recording"]
+        ends = df["effective_end_recording"]
 
-        # Vectorised interval coverage
-        t_vals = time_index.to_numpy()[:, None]
-        start_vals = df["effective_start_recording"].to_numpy()
-        end_vals = df["effective_end_recording"].to_numpy()
+        # +1 at each start, -1 at each end
+        events = concat([
+            Series(1, index=starts),
+            Series(-1, index=ends),
+        ]).sort_index()
 
-        # Boolean matrix: True if the timestamp is within any recording interval
-        covered = (t_vals >= start_vals) & (t_vals < end_vals)
-        effort[:] = covered.any(axis=1).astype(int)
+        # combine events that fall on the exact same timestamp
+        events = events.groupby(level=0).sum()
+
+        # running count of "how many intervals are active" at each event time
+        coverage = events.cumsum()
+
+        # project onto your regular time_index: carry the last known coverage forward
+        effort = coverage.reindex(time_index, method="ffill").fillna(0)
+        effort = (effort > 0).astype(int)
 
         # Aggregate effort into user-defined bin_size
         counts = effort.resample(bin_size, closed="left", label="left").sum()
@@ -146,9 +153,9 @@ class RecordingPeriod:
             msg = "CSV is empty."
             raise ValueError(msg)
 
-        # Normalise timezones: convert to UTC, then remove tz info (naive)
+        # Normalize timezones: convert to UTC, then remove tz info (naive)
         for col in df.columns:
-            df[col] = to_datetime(df[col], utc=True).dt.tz_convert(None)
+            df[col] = to_datetime(df[col], utc=True)
 
         return df
 

--- a/tests/test_recording_period.py
+++ b/tests/test_recording_period.py
@@ -53,7 +53,7 @@ def test_recording_period_with_gaps(
         "start_deployment",
         "end_deployment",
     ]:
-        df_planning[col] = to_datetime(df_planning[col], utc=True).dt.tz_convert(None)
+        df_planning[col] = to_datetime(df_planning[col], utc=True)
 
     df_planning["start"] = df_planning[["start_recording", "start_deployment"]].max(
         axis=1


### PR DESCRIPTION
`get_count` previously built bin edges over the entire requested time span regardless of actual recording coverage, so cut/value_counts iterated over potentially millions of bins with no data.

This PR adds an optional effort: RecordingPeriod parameter.
When provided, `RecordingPeriod` is used to identify only the bins with actual recording activity, and bin edges are built from those active bins alone. Events outside the active window span are filtered out before the per-label/annotator grouping.

This avoids computing/counting empty bins entirely, reducing runtime on datasets with large inactive gaps between recording periods.